### PR TITLE
Provide jobqueue config and example notebook

### DIFF
--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -11,6 +11,7 @@
     "* specify batch queue and project budget name\n",
     "* open, scale and close a default jobqueue cluster\n",
     "* do an example calculation on larger than memory data\n",
+    "\n",
     "NOTE: Currently, this **only works** if Jupyter is running **on** a **compute node**."
    ]
   },

--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -1,0 +1,635 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dask jobqueue example for JUWELS at JSC\n",
+    "covers the following aspects, i.e. how to\n",
+    "* add the JUWELS specific Dask jobqueue configuration\n",
+    "* get overview on available JUWELS compute node resources\n",
+    "* specify batch queue and project budget name\n",
+    "* open, scale and close a default jobqueue cluster\n",
+    "* do an example calculation on larger than memory data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask, dask_jobqueue\n",
+    "import dask.distributed as dask_distributed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load jobqueue configuration defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "additional_config = dask.config.collect(paths=['.']) # look up further Dask configurations in local directory\n",
+    "dask.config.update(dask.config.config, additional_config, priority='new');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cores': 96,\n",
+       " 'memory': '90000M',\n",
+       " 'processes': 1,\n",
+       " 'local-directory': '/tmp',\n",
+       " 'interface': 'ib0',\n",
+       " 'death-timeout': 60,\n",
+       " 'shebang': '#!/usr/bin/env bash',\n",
+       " 'walltime': '00:15:00',\n",
+       " 'log-directory': 'dask_jobqueue_logs',\n",
+       " 'name': 'dask-worker',\n",
+       " 'queue': None,\n",
+       " 'project': None,\n",
+       " 'job-cpu': None,\n",
+       " 'job-mem': None,\n",
+       " 'job-extra': [],\n",
+       " 'extra': [],\n",
+       " 'env-extra': []}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dask.config.get('jobqueue.juwels-jobqueue-config')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up jobqueue cluster ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PARTITION AVAIL NODES STATE\n",
+      "batch*       up    10  idle\n",
+      "mem192       up     1  idle\n",
+      "gpus         up     0   n/a\n",
+      "devel        up     2  idle\n",
+      "esm          up     3  idle\n",
+      "develgpus    up     6  idle\n",
+      "large      down    10  idle\n",
+      "maint        up    21  idle\n"
+     ]
+    }
+   ],
+   "source": [
+    "!sinfo -t idle --format=\"%9P %.5a %.5D %.5t\" # get overview on available resources per queue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobqueue_cluster = dask_jobqueue.SLURMCluster(config_name='juwels-jobqueue-config',\n",
+    "                                              project='esmtst', # specify budget name associated with project\n",
+    "                                              queue='esm') # choose queue by available resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#!/usr/bin/env bash\n",
+      "\n",
+      "#SBATCH -J dask-worker\n",
+      "#SBATCH -e dask_jobqueue_logs/dask-worker-%J.err\n",
+      "#SBATCH -o dask_jobqueue_logs/dask-worker-%J.out\n",
+      "#SBATCH -p esm\n",
+      "#SBATCH -A esmtst\n",
+      "#SBATCH -n 1\n",
+      "#SBATCH --cpus-per-task=96\n",
+      "#SBATCH --mem=84G\n",
+      "#SBATCH -t 00:15:00\n",
+      "\n",
+      "JOB_ID=${SLURM_JOB_ID%;*}\n",
+      "\n",
+      "/p/project/cesmtst/hoeflich1/miniconda3/envs/Dask-jobqueue_v2020.02.10/bin/python -m distributed.cli.dask_worker tcp://10.11.128.23:33762 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --interface ib0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(jobqueue_cluster.job_script())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ... and the client process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = dask_distributed.Client(jobqueue_cluster)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start jobqueue workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobqueue_cluster.scale(jobs=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
+      "           2144135       esm dask-wor hoeflich  R       0:06      1 jwc00n000\n",
+      "           2144134       esm interact hoeflich  R       1:24      1 jwc00n009\n"
+     ]
+    }
+   ],
+   "source": [
+    "!squeue -u hoeflich1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>tcp://10.11.128.23:33762</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.11.128.23:8787/status' target='_blank'>http://10.11.128.23:8787/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>1</li>\n",
+       "  <li><b>Cores: </b>96</li>\n",
+       "  <li><b>Memory: </b>90.00 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://10.11.128.23:33762' processes=1 threads=96, memory=90.00 GB>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Do calculation on larger than memory data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.array as da"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<tr>\n",
+       "<td>\n",
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr><td> </td><th> Array </th><th> Chunk </th></tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr><th> Bytes </th><td> 292.00 GB </td> <td> 730.00 MB </td></tr>\n",
+       "    <tr><th> Shape </th><td> (365, 10000, 10000) </td> <td> (365, 500, 500) </td></tr>\n",
+       "    <tr><th> Count </th><td> 400 Tasks </td><td> 400 Chunks </td></tr>\n",
+       "    <tr><th> Type </th><td> float64 </td><td> numpy.ndarray </td></tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</td>\n",
+       "<td>\n",
+       "<svg width=\"199\" height=\"189\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"29\" y2=\"19\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"6\" x2=\"29\" y2=\"25\" />\n",
+       "  <line x1=\"10\" y1=\"12\" x2=\"29\" y2=\"31\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"29\" y2=\"37\" />\n",
+       "  <line x1=\"10\" y1=\"24\" x2=\"29\" y2=\"43\" />\n",
+       "  <line x1=\"10\" y1=\"30\" x2=\"29\" y2=\"49\" />\n",
+       "  <line x1=\"10\" y1=\"36\" x2=\"29\" y2=\"55\" />\n",
+       "  <line x1=\"10\" y1=\"42\" x2=\"29\" y2=\"61\" />\n",
+       "  <line x1=\"10\" y1=\"48\" x2=\"29\" y2=\"67\" />\n",
+       "  <line x1=\"10\" y1=\"54\" x2=\"29\" y2=\"73\" />\n",
+       "  <line x1=\"10\" y1=\"60\" x2=\"29\" y2=\"79\" />\n",
+       "  <line x1=\"10\" y1=\"66\" x2=\"29\" y2=\"85\" />\n",
+       "  <line x1=\"10\" y1=\"72\" x2=\"29\" y2=\"91\" />\n",
+       "  <line x1=\"10\" y1=\"78\" x2=\"29\" y2=\"97\" />\n",
+       "  <line x1=\"10\" y1=\"84\" x2=\"29\" y2=\"103\" />\n",
+       "  <line x1=\"10\" y1=\"90\" x2=\"29\" y2=\"109\" />\n",
+       "  <line x1=\"10\" y1=\"96\" x2=\"29\" y2=\"115\" />\n",
+       "  <line x1=\"10\" y1=\"102\" x2=\"29\" y2=\"121\" />\n",
+       "  <line x1=\"10\" y1=\"108\" x2=\"29\" y2=\"127\" />\n",
+       "  <line x1=\"10\" y1=\"114\" x2=\"29\" y2=\"133\" />\n",
+       "  <line x1=\"10\" y1=\"120\" x2=\"29\" y2=\"139\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"29\" y1=\"19\" x2=\"29\" y2=\"139\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.000000,0.000000 29.161809,19.161809 29.161809,139.161809 10.000000,120.000000\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"29\" y1=\"19\" x2=\"149\" y2=\"19\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"29\" y2=\"19\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"0\" x2=\"35\" y2=\"19\" />\n",
+       "  <line x1=\"22\" y1=\"0\" x2=\"41\" y2=\"19\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"47\" y2=\"19\" />\n",
+       "  <line x1=\"34\" y1=\"0\" x2=\"53\" y2=\"19\" />\n",
+       "  <line x1=\"40\" y1=\"0\" x2=\"59\" y2=\"19\" />\n",
+       "  <line x1=\"46\" y1=\"0\" x2=\"65\" y2=\"19\" />\n",
+       "  <line x1=\"52\" y1=\"0\" x2=\"71\" y2=\"19\" />\n",
+       "  <line x1=\"58\" y1=\"0\" x2=\"77\" y2=\"19\" />\n",
+       "  <line x1=\"64\" y1=\"0\" x2=\"83\" y2=\"19\" />\n",
+       "  <line x1=\"70\" y1=\"0\" x2=\"89\" y2=\"19\" />\n",
+       "  <line x1=\"76\" y1=\"0\" x2=\"95\" y2=\"19\" />\n",
+       "  <line x1=\"82\" y1=\"0\" x2=\"101\" y2=\"19\" />\n",
+       "  <line x1=\"88\" y1=\"0\" x2=\"107\" y2=\"19\" />\n",
+       "  <line x1=\"94\" y1=\"0\" x2=\"113\" y2=\"19\" />\n",
+       "  <line x1=\"100\" y1=\"0\" x2=\"119\" y2=\"19\" />\n",
+       "  <line x1=\"106\" y1=\"0\" x2=\"125\" y2=\"19\" />\n",
+       "  <line x1=\"112\" y1=\"0\" x2=\"131\" y2=\"19\" />\n",
+       "  <line x1=\"118\" y1=\"0\" x2=\"137\" y2=\"19\" />\n",
+       "  <line x1=\"124\" y1=\"0\" x2=\"143\" y2=\"19\" />\n",
+       "  <line x1=\"130\" y1=\"0\" x2=\"149\" y2=\"19\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.000000,0.000000 130.000000,0.000000 149.161809,19.161809 29.161809,19.161809\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"29\" y1=\"19\" x2=\"149\" y2=\"19\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"29\" y1=\"25\" x2=\"149\" y2=\"25\" />\n",
+       "  <line x1=\"29\" y1=\"31\" x2=\"149\" y2=\"31\" />\n",
+       "  <line x1=\"29\" y1=\"37\" x2=\"149\" y2=\"37\" />\n",
+       "  <line x1=\"29\" y1=\"43\" x2=\"149\" y2=\"43\" />\n",
+       "  <line x1=\"29\" y1=\"49\" x2=\"149\" y2=\"49\" />\n",
+       "  <line x1=\"29\" y1=\"55\" x2=\"149\" y2=\"55\" />\n",
+       "  <line x1=\"29\" y1=\"61\" x2=\"149\" y2=\"61\" />\n",
+       "  <line x1=\"29\" y1=\"67\" x2=\"149\" y2=\"67\" />\n",
+       "  <line x1=\"29\" y1=\"73\" x2=\"149\" y2=\"73\" />\n",
+       "  <line x1=\"29\" y1=\"79\" x2=\"149\" y2=\"79\" />\n",
+       "  <line x1=\"29\" y1=\"85\" x2=\"149\" y2=\"85\" />\n",
+       "  <line x1=\"29\" y1=\"91\" x2=\"149\" y2=\"91\" />\n",
+       "  <line x1=\"29\" y1=\"97\" x2=\"149\" y2=\"97\" />\n",
+       "  <line x1=\"29\" y1=\"103\" x2=\"149\" y2=\"103\" />\n",
+       "  <line x1=\"29\" y1=\"109\" x2=\"149\" y2=\"109\" />\n",
+       "  <line x1=\"29\" y1=\"115\" x2=\"149\" y2=\"115\" />\n",
+       "  <line x1=\"29\" y1=\"121\" x2=\"149\" y2=\"121\" />\n",
+       "  <line x1=\"29\" y1=\"127\" x2=\"149\" y2=\"127\" />\n",
+       "  <line x1=\"29\" y1=\"133\" x2=\"149\" y2=\"133\" />\n",
+       "  <line x1=\"29\" y1=\"139\" x2=\"149\" y2=\"139\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"29\" y1=\"19\" x2=\"29\" y2=\"139\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"35\" y1=\"19\" x2=\"35\" y2=\"139\" />\n",
+       "  <line x1=\"41\" y1=\"19\" x2=\"41\" y2=\"139\" />\n",
+       "  <line x1=\"47\" y1=\"19\" x2=\"47\" y2=\"139\" />\n",
+       "  <line x1=\"53\" y1=\"19\" x2=\"53\" y2=\"139\" />\n",
+       "  <line x1=\"59\" y1=\"19\" x2=\"59\" y2=\"139\" />\n",
+       "  <line x1=\"65\" y1=\"19\" x2=\"65\" y2=\"139\" />\n",
+       "  <line x1=\"71\" y1=\"19\" x2=\"71\" y2=\"139\" />\n",
+       "  <line x1=\"77\" y1=\"19\" x2=\"77\" y2=\"139\" />\n",
+       "  <line x1=\"83\" y1=\"19\" x2=\"83\" y2=\"139\" />\n",
+       "  <line x1=\"89\" y1=\"19\" x2=\"89\" y2=\"139\" />\n",
+       "  <line x1=\"95\" y1=\"19\" x2=\"95\" y2=\"139\" />\n",
+       "  <line x1=\"101\" y1=\"19\" x2=\"101\" y2=\"139\" />\n",
+       "  <line x1=\"107\" y1=\"19\" x2=\"107\" y2=\"139\" />\n",
+       "  <line x1=\"113\" y1=\"19\" x2=\"113\" y2=\"139\" />\n",
+       "  <line x1=\"119\" y1=\"19\" x2=\"119\" y2=\"139\" />\n",
+       "  <line x1=\"125\" y1=\"19\" x2=\"125\" y2=\"139\" />\n",
+       "  <line x1=\"131\" y1=\"19\" x2=\"131\" y2=\"139\" />\n",
+       "  <line x1=\"137\" y1=\"19\" x2=\"137\" y2=\"139\" />\n",
+       "  <line x1=\"143\" y1=\"19\" x2=\"143\" y2=\"139\" />\n",
+       "  <line x1=\"149\" y1=\"19\" x2=\"149\" y2=\"139\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"29.161809,19.161809 149.161809,19.161809 149.161809,139.161809 29.161809,139.161809\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Text -->\n",
+       "  <text x=\"89.161809\" y=\"159.161809\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >10000</text>\n",
+       "  <text x=\"169.161809\" y=\"79.161809\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,169.161809,79.161809)\">10000</text>\n",
+       "  <text x=\"9.580905\" y=\"149.580905\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,9.580905,149.580905)\">365</text>\n",
+       "</svg>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "dask.array<uniform, shape=(365, 10000, 10000), dtype=float64, chunksize=(365, 500, 500), chunktype=numpy.ndarray>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fake_data = da.random.uniform(0, 1, size=(365, 1e4, 1e4), chunks=(365,500,500)) # problem specific chunking\n",
+    "fake_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "elapse time  11.243258953094482  in seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time = time.time()\n",
+    "fake_data.mean(axis=0).compute()\n",
+    "elapsed = time.time() - start_time\n",
+    "print('elapse time ',elapsed,' in seconds')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Close jobqueue cluster and client process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
+      "           2144135       esm dask-wor hoeflich  R       0:36      1 jwc00n000\n",
+      "           2144134       esm interact hoeflich  R       1:54      1 jwc00n009\n"
+     ]
+    }
+   ],
+   "source": [
+    "!squeue -u hoeflich1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobqueue_cluster.close()\n",
+    "client.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
+      "           2144134       esm interact hoeflich  R       2:04      1 jwc00n009\n"
+     ]
+    }
+   ],
+   "source": [
+    "!squeue -u hoeflich1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conda environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# This file may be used to create an environment using:\n",
+      "# $ conda create --name <env> --file <this file>\n",
+      "# platform: linux-64\n",
+      "@EXPLICIT\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2019.11.28-hecc5488_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.33.1-h53a641e_8.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.3.0-hdf63c60_5.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.2.0-hdf63c60_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.2.0-h24d8f2e_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-0_gnu.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.2.0-h24d8f2e_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9c-h14c3975_1001.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1006.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.7-h5ec1e0e_6.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.17-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.8.3-he1b5a44_1001.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.1-hf484d3e_1002.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1d-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.4-h14c3975_1001.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.2-h516909a_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1006.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.8.0-14_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-hed695b0_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-hf8c457e_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-hed695b0_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.4-h3b9ef0a_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.0-he983fc9_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-14_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-14_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.1.0-hc3755c2_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.30.1-hcee41ef_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/python-3.8.1-h357f687_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.1.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2019.11.28-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/click-7.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.2.2-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2.10.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/entrypoints-0.3-py38_1000.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.6.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py38h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-0.6.2-py38hc9558a2_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.18.1-py38h95a1406_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/olefile-0.46-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/parso-0.6.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pickleshare-0.7.5-py38_1000.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.6.7-py38h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.6.0-py_1001.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.6-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pytz-2019.3-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3-py38h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-18.1.1-py38h1768529_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/six-1.14.0-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.1.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/tblib-1.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/toolz-0.10.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.0.3-py38h516909a_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.1.8-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.10.1-py38h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.16.0-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/partd-1.1.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pexpect-4.8.0-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.0.0-py38hefe7db6_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/setuptools-45.2.0-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/traitlets-4.3.3-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zict-1.0.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/distributed-2.10.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.1-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.0.1-py38hb3f55d8_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.5.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wheel-0.34.2-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-1.4.0-py38_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_client-5.3.4-py38_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pip-20.0.2-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.3-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-2.10.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.12.0-py38h5ca1d4c_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.1.4-py38h5ca1d4c_0.tar.bz2\n"
+     ]
+    }
+   ],
+   "source": [
+    "!conda list --explicit"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:Dask-jobqueue_v2020.02.10]",
+   "language": "python",
+   "name": "conda-env-Dask-jobqueue_v2020.02.10-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -10,7 +10,8 @@
     "* get overview on available JUWELS compute node resources\n",
     "* specify batch queue and project budget name\n",
     "* open, scale and close a default jobqueue cluster\n",
-    "* do an example calculation on larger than memory data"
+    "* do an example calculation on larger than memory data\n",
+    "NOTE: Currently, this **only works** if Jupyter is running **on** a **compute node**."
    ]
   },
   {

--- a/juwels/juwels-dask-jobqueue-config.yaml
+++ b/juwels/juwels-dask-jobqueue-config.yaml
@@ -1,0 +1,41 @@
+
+jobqueue:
+
+  juwels-jobqueue-config:
+
+    ### Dask jobqueue worker options ###
+
+    # specify complete node resources
+    # as compute time is charged using XXXXXXXX
+
+    cores: 96        # based on 24 physical cores via hyperthreading
+    memory: 90000M   # via `scontrol show node jwc00n018`
+    processes: 1
+
+    local-directory: /tmp
+    interface: ib0
+
+    death-timeout: 60
+
+    ### SLURM job script options ####
+
+    shebang: '#!/usr/bin/env bash'
+    walltime: '00:15:00'
+    log-directory: dask_jobqueue_logs
+    name: dask-worker
+
+    # depends on project affiliation
+    # and should be set manually!
+    queue: null
+    project: null
+
+    # these are automatically set
+    # by the Dask worker options above
+    job-cpu: null
+    job-mem: null
+
+    # mandatory for
+    # standalone configurations
+    job-extra: []
+    extra: []
+    env-extra: []

--- a/juwels/juwels-dask-jobqueue-config.yaml
+++ b/juwels/juwels-dask-jobqueue-config.yaml
@@ -5,16 +5,12 @@ jobqueue:
 
     ### Dask jobqueue worker options ###
 
-    # specify complete node resources
-    # as compute time is charged using XXXXXXXX
-
-    cores: 96        # based on 24 physical cores via hyperthreading
-    memory: 90000M   # via `scontrol show node jwc00n018`
+    cores: 96        # use full node CPU and memory resources
+    memory: 90000M   # e.g. $ control show node jwc00n018
     processes: 1
 
     local-directory: /tmp
     interface: ib0
-
     death-timeout: 60
 
     ### SLURM job script options ####
@@ -24,18 +20,21 @@ jobqueue:
     log-directory: dask_jobqueue_logs
     name: dask-worker
 
-    # depends on project affiliation
-    # and should be set manually!
+    # depend on project affiliation
+    # should be set manually!
+    
     queue: null
     project: null
 
     # these are automatically set
     # by the Dask worker options above
+    
     job-cpu: null
     job-mem: null
 
     # mandatory for
     # standalone configurations
+    
     job-extra: []
     extra: []
     env-extra: []


### PR DESCRIPTION
I have put together a working default Dask jobqueue configuration for JUWELS today (which needs some clean up, but I will do that later). However, as long as https://github.com/dask/dask-jobqueue/issues/382 isn't resolved, opening a Dask jobqueue cluster does not work and we probably should not yet merge this.

(To circumvent the login/compute node interfacing problems, the example notebook was run in an interactive session JupyterLab instance, i.e. JupyterLab also located on a compute node. However, I think this is not a recommended workflow as only full nodes can be allocated on JUWELS and the JupyterLab compute node would be left idling most of the time. Doing calculations locally, i.e. opening a Dask local cluster would avoid this and might be a temporary solution.)