### PR TITLE
Provide fully working JUWELS defaults

### DIFF
--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -10,9 +10,7 @@
     "* get overview on available JUWELS compute node resources\n",
     "* specify batch queue and project budget name\n",
     "* open, scale and close a default jobqueue cluster\n",
-    "* do an example calculation on larger than memory data\n",
-    "\n",
-    "NOTE: Currently, this **only works** if Jupyter is running **on** a **compute node**."
+    "* do an example calculation on larger than memory data"
    ]
   },
   {
@@ -21,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dask, dask_jobqueue\n",
+    "import dask, dask_jobqueue, os\n",
     "import dask.distributed as dask_distributed"
    ]
   },
@@ -54,8 +52,9 @@
        " 'memory': '90000M',\n",
        " 'processes': 1,\n",
        " 'local-directory': '/tmp',\n",
-       " 'interface': 'ib0',\n",
        " 'death-timeout': 60,\n",
+       " 'extra': ['--host ${SLURMD_NODENAME}.ib.juwels.fzj.de'],\n",
+       " 'interface': None,\n",
        " 'shebang': '#!/usr/bin/env bash',\n",
        " 'walltime': '00:15:00',\n",
        " 'log-directory': 'dask_jobqueue_logs',\n",
@@ -65,7 +64,6 @@
        " 'job-cpu': None,\n",
        " 'job-mem': None,\n",
        " 'job-extra': [],\n",
-       " 'extra': [],\n",
        " 'env-extra': []}"
       ]
      },
@@ -95,14 +93,14 @@
      "output_type": "stream",
      "text": [
       "PARTITION AVAIL NODES STATE\n",
-      "batch*       up    10  idle\n",
-      "mem192       up     1  idle\n",
+      "batch*       up   141  idle\n",
+      "mem192       up    10  idle\n",
       "gpus         up     0   n/a\n",
-      "devel        up     2  idle\n",
-      "esm          up     3  idle\n",
-      "develgpus    up     6  idle\n",
-      "large      down    10  idle\n",
-      "maint        up    21  idle\n"
+      "devel        up    20  idle\n",
+      "esm          up     5  idle\n",
+      "develgpus    up     9  idle\n",
+      "large      down   141  idle\n",
+      "maint        up   175  idle\n"
      ]
     }
    ],
@@ -118,7 +116,8 @@
    "source": [
     "jobqueue_cluster = dask_jobqueue.SLURMCluster(config_name='juwels-jobqueue-config',\n",
     "                                              project='esmtst', # specify budget name associated with project\n",
-    "                                              queue='esm') # choose queue by available resources"
+    "                                              queue='esm', # choose queue by available resources\n",
+    "                                              host=os.environ['HOSTNAME']) # globally visible local scheduler network location"
    ]
   },
   {
@@ -144,7 +143,7 @@
       "\n",
       "JOB_ID=${SLURM_JOB_ID%;*}\n",
       "\n",
-      "/p/project/cesmtst/hoeflich1/miniconda3/envs/Dask-jobqueue_v2020.02.10/bin/python -m distributed.cli.dask_worker tcp://10.11.128.23:33762 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --interface ib0\n",
+      "/p/project/cesmtst/hoeflich1/miniconda3/envs/Dask-jobqueue_v2020.02.10/bin/python -m distributed.cli.dask_worker tcp://10.11.159.196:37444 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --host ${SLURMD_NODENAME}.ib.juwels.fzj.de\n",
       "\n"
      ]
     }
@@ -187,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -195,8 +194,7 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2144135       esm dask-wor hoeflich  R       0:06      1 jwc00n000\n",
-      "           2144134       esm interact hoeflich  R       1:24      1 jwc00n009\n"
+      "           2164705       esm dask-wor hoeflich  R       0:23      1 jwc00n003\n"
      ]
     }
    ],
@@ -206,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -217,8 +215,8 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://10.11.128.23:33762</li>\n",
-       "  <li><b>Dashboard: </b><a href='http://10.11.128.23:8787/status' target='_blank'>http://10.11.128.23:8787/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.11.159.196:37444</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.11.159.196:8787/status' target='_blank'>http://10.11.159.196:8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
@@ -233,10 +231,10 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: 'tcp://10.11.128.23:33762' processes=1 threads=96, memory=90.00 GB>"
+       "<Client: 'tcp://10.11.159.196:37444' processes=1 threads=96, memory=90.00 GB>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -409,7 +407,7 @@
        "dask.array<uniform, shape=(365, 10000, 10000), dtype=float64, chunksize=(365, 500, 500), chunktype=numpy.ndarray>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -421,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,14 +428,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "elapse time  11.243258953094482  in seconds\n"
+      "elapse time  12.483904123306274  in seconds\n"
      ]
     }
    ],
@@ -457,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -465,8 +463,7 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2144135       esm dask-wor hoeflich  R       0:36      1 jwc00n000\n",
-      "           2144134       esm interact hoeflich  R       1:54      1 jwc00n009\n"
+      "           2164705       esm dask-wor hoeflich  R       1:06      1 jwc00n003\n"
      ]
     }
    ],
@@ -476,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,15 +483,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2144134       esm interact hoeflich  R       2:04      1 jwc00n009\n"
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n"
      ]
     }
    ],
@@ -511,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -611,6 +607,13 @@
    "source": [
     "!conda list --explicit"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -114,10 +114,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jobqueue_cluster = dask_jobqueue.SLURMCluster(config_name='juwels-jobqueue-config',\n",
-    "                                              project='esmtst', # specify budget name associated with project\n",
-    "                                              queue='esm', # choose queue by available resources\n",
-    "                                              host=os.environ['HOSTNAME']) # globally visible local scheduler network location"
+    "jobqueue_cluster = dask_jobqueue.SLURMCluster(\n",
+    "    config_name='juwels-jobqueue-config',\n",
+    "    project='esmtst', # specify budget name associated with project\n",
+    "    queue='esm', # choose queue by available resources\n",
+    "    host=os.environ['HOSTNAME']) # globally visible local scheduler network location"
    ]
   },
   {

--- a/juwels/juwels-dask-jobqueue-config.yaml
+++ b/juwels/juwels-dask-jobqueue-config.yaml
@@ -7,11 +7,14 @@ jobqueue:
 
     cores: 96        # use full node CPU and memory resources
     memory: 90000M   # e.g. $ control show node jwc00n018
-    processes: 1
+    
+    processes: 1     # good only for pure Numpy workflows
 
     local-directory: /tmp
-    interface: ib0
     death-timeout: 60
+
+    extra: ['--host ${SLURMD_NODENAME}.ib.juwels.fzj.de'] # globally visible compute node network location
+    interface: null  # don't use this option!
 
     ### SLURM job script options ####
 
@@ -36,5 +39,4 @@ jobqueue:
     # standalone configurations
     
     job-extra: []
-    extra: []
     env-extra: []


### PR DESCRIPTION
Implements the globally visible JUWELS login and compute node network locations `<hostname>.ib.juwels.fzj.de` for both Dask scheduler and workers. Thanks! @kthust (This should sort out the interface conflicts for Dask jobqueue on JUWELS.)