### PR TITLE
Adapt for scheduler options and use user from env

### DIFF
--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -93,14 +93,14 @@
      "output_type": "stream",
      "text": [
       "PARTITION AVAIL NODES STATE\n",
-      "batch*       up   141  idle\n",
-      "mem192       up    10  idle\n",
-      "gpus         up     0   n/a\n",
-      "devel        up    20  idle\n",
+      "batch*       up   152  idle\n",
+      "devel        up    17  idle\n",
+      "mem192       up     9  idle\n",
       "esm          up     5  idle\n",
-      "develgpus    up     9  idle\n",
-      "large      down   141  idle\n",
-      "maint        up   175  idle\n"
+      "large      down   152  idle\n",
+      "gpus         up    17  idle\n",
+      "develgpus    up     5  idle\n",
+      "maint        up   196  idle\n"
      ]
     }
    ],
@@ -112,13 +112,25 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/p/home/jusers/rath1/juwels/PROJECT_training2005/2020-08_dask_intro/miniconda3/envs/py3_dask/lib/python3.7/site-packages/distributed/node.py:155: UserWarning: Port 8787 is already in use.\n",
+      "Perhaps you already have a cluster running?\n",
+      "Hosting the HTTP server on port 36816 instead\n",
+      "  http_address[\"port\"], self.http_server.port\n"
+     ]
+    }
+   ],
    "source": [
     "jobqueue_cluster = dask_jobqueue.SLURMCluster(\n",
     "    config_name='juwels-jobqueue-config',\n",
     "    project='esmtst', # specify budget name associated with project\n",
     "    queue='esm', # choose queue by available resources\n",
-    "    host=os.environ['HOSTNAME']) # globally visible local scheduler network location"
+    "    scheduler_options={\"host\": os.environ['HOSTNAME']} # globally visible local scheduler network location\n",
+    ")"
    ]
   },
   {
@@ -142,9 +154,7 @@
       "#SBATCH --mem=84G\n",
       "#SBATCH -t 00:15:00\n",
       "\n",
-      "JOB_ID=${SLURM_JOB_ID%;*}\n",
-      "\n",
-      "/p/project/cesmtst/hoeflich1/miniconda3/envs/Dask-jobqueue_v2020.02.10/bin/python -m distributed.cli.dask_worker tcp://10.11.159.196:37444 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --host ${SLURMD_NODENAME}.ib.juwels.fzj.de\n",
+      "/p/home/jusers/rath1/juwels/PROJECT_training2005/2020-08_dask_intro/miniconda3/envs/py3_dask/bin/python -m distributed.cli.dask_worker tcp://10.11.159.191:43724 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --host ${SLURMD_NODENAME}.ib.juwels.fzj.de\n",
       "\n"
      ]
     }
@@ -187,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -195,17 +205,17 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2164705       esm dask-wor hoeflich  R       0:23      1 jwc00n003\n"
+      "           2524520       esm dask-wor    rath1 CF       0:00      1 jwc00n003\n"
      ]
     }
    ],
    "source": [
-    "!squeue -u hoeflich1"
+    "!squeue -u {os.environ[\"USER\"]}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -216,26 +226,26 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://10.11.159.196:37444</li>\n",
-       "  <li><b>Dashboard: </b><a href='http://10.11.159.196:8787/status' target='_blank'>http://10.11.159.196:8787/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.11.159.191:43724</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.11.159.191:36816/status' target='_blank'>http://10.11.159.191:36816/status</a></li>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Cluster</h3>\n",
        "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>1</li>\n",
-       "  <li><b>Cores: </b>96</li>\n",
-       "  <li><b>Memory: </b>90.00 GB</li>\n",
+       "  <li><b>Workers: </b>0</li>\n",
+       "  <li><b>Cores: </b>0</li>\n",
+       "  <li><b>Memory: </b>0 B</li>\n",
        "</ul>\n",
        "</td>\n",
        "</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "<Client: 'tcp://10.11.159.196:37444' processes=1 threads=96, memory=90.00 GB>"
+       "<Client: 'tcp://10.11.159.191:43724' processes=0 threads=0, memory=0 B>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +418,7 @@
        "dask.array<uniform, shape=(365, 10000, 10000), dtype=float64, chunksize=(365, 500, 500), chunktype=numpy.ndarray>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,14 +439,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "elapse time  12.483904123306274  in seconds\n"
+      "elapse time  14.90658164024353  in seconds\n"
      ]
     }
    ],
@@ -456,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -464,17 +474,17 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2164705       esm dask-wor hoeflich  R       1:06      1 jwc00n003\n"
+      "           2524520       esm dask-wor    rath1  R       0:20      1 jwc00n003\n"
      ]
     }
    ],
    "source": [
-    "!squeue -u hoeflich1"
+    "!squeue -u {os.environ[\"USER\"]}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,19 +494,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n"
+      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
+      "           2524520       esm dask-wor    rath1 CG       0:20      1 jwc00n003\n"
      ]
     }
    ],
    "source": [
-    "!squeue -u hoeflich1"
+    "!squeue -u {os.environ[\"USER\"]}"
    ]
   },
   {
@@ -508,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -520,108 +531,127 @@
       "# platform: linux-64\n",
       "@EXPLICIT\n",
       "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2019.11.28-hecc5488_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.33.1-h53a641e_8.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.3.0-hdf63c60_5.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.2.0-hdf63c60_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.2.0-h24d8f2e_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-0_gnu.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.2.0-h24d8f2e_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9c-h14c3975_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1006.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.7-h5ec1e0e_6.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.17-h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.8.3-he1b5a44_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.1-hf484d3e_1002.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1d-h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.4-h14c3975_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.2-h516909a_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1006.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-hed695b0_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-hf8c457e_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2020.6.20-hecda079_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.34-hc38a660_9.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.5.0-hdf63c60_15.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.3.0-hdf63c60_15.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.3.0-h24d8f2e_15.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-1_gnu.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.3.0-h24d8f2e_15.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h516909a_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.16.1-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9d-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1007.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.10-pthreads_hb3c22a3_4.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.1.0-h516909a_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.2-he1b5a44_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.2-he1b5a44_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1g-h516909a_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.5-h516909a_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1007.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.13-hf30be14_1003.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.10.6-nompi_h3c11f04_101.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.8.0-17_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.41.0-hab1572f_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-hed695b0_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.9.0-hab1572f_5.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-he28a2e2_2.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-hed695b0_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.4-h3b9ef0a_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.0-he983fc9_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.1.0-hc3755c2_3.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.30.1-hcee41ef_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/python-3.8.1-h357f687_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.1.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2019.11.28-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/click-7.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.2.2-py_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2.10.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/entrypoints-0.3-py38_1000.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.6.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.5-h6597ccf_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.2-he06d7ca_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.1-hfafb76e_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-17_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-17_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.1.0-hc7e4089_6.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.32.3-h4cf870e_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.11-hbd6801e_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libcurl-7.71.1-hcdd3856_4.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/python-3.7.8-h6f2ec95_1_cpython.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/click-7.1.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.5.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/curl-7.71.1-he644dc0_4.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.8.0-py_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-0.6.2-py38hc9558a2_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.18.1-py38h95a1406_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/monotonic-1.5-py_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/olefile-0.46-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/parso-0.6.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pickleshare-0.7.5-py38_1000.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.6.7-py38h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.0-pyh9f0ad1d_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.6.0-py_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.6-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pytz-2019.3-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-18.1.1-py38h1768529_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/six-1.14.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.1.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.7-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.7-1_cp37m.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pytz-2020.1-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/six-1.15.0-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.2.2-pyh9f0ad1d_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/tblib-1.6.0-py_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/toolz-0.10.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.0.3-py38h516909a_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.1.8-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.10.1-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.16.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.7.4.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wheel-0.35.1-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2020.6.20-py37hc8dfbb8_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.10.1-py37h516909a_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/fasteners-0.14.1-py_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.15.2-py37_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.7.4-nompi_h84807e1_105.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py37h8f50634_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.0-py37h99015e2_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.19.1-py37h8960a57_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.4-pyh9f0ad1d_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/partd-1.1.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pexpect-4.8.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.0.0-py38hefe7db6_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pexpect-4.8.0-py37hc8dfbb8_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pickleshare-0.7.5-py37hc8dfbb8_1001.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.2.0-py37h718be6c_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.7.2-py37h8f50634_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/setuptools-45.2.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/traitlets-4.3.3-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/zict-1.0.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/distributed-2.10.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.1-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.0.1-py38hb3f55d8_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.5.2-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/wheel-0.34.2-py_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-1.4.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_client-5.3.4-py38_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pip-20.0.2-py_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.3-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-2.10.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.12.0-py38h5ca1d4c_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.1.4-py38h5ca1d4c_0.tar.bz2\n"
+      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3.1-py37h8f50634_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-19.0.2-py37hac76be4_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.0.4-py37h8f50634_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/traitlets-4.3.3-py37hc8dfbb8_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zict-2.0.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/cftime-1.2.1-py37h03ebfcd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2.23.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.3-py37hc8dfbb8_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.6.4-py37he1b5a44_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.0-py37h3340039_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/scipy-1.5.2-py37hb14ef9d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py37hc8dfbb8_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/distributed-2.23.0-py37hc8dfbb8_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyter_client-6.1.6-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.5.4-nompi_py37hdc49583_100.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pip-20.2.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.6.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zarr-2.4.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.1.1-py37hc8dfbb8_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-2.23.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.6-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.17.0-py37hc6149b9_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.3.4-py37h43977f1_0.tar.bz2\n"
      ]
     }
    ],
    "source": [
     "!conda list --explicit"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:Dask-jobqueue_v2020.02.10]",
+   "display_name": "Python [conda env:py3_dask]",
    "language": "python",
-   "name": "conda-env-Dask-jobqueue_v2020.02.10-py"
+   "name": "conda-env-py3_dask-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -633,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes a deprecation issue: The `host=` kwarg of Dask Jobqueue now goes into the `scheduler_config`.

And it uses a more generic `os.environ["USER"]` when querying the SLURM scheduler.

Note that the Nesh part should be adapted as well. But maybe in a separate PR?