### PR TITLE
Adapt JUWELS config for the recent machine update

### DIFF
--- a/jupyterlab.sh
+++ b/jupyterlab.sh
@@ -1,0 +1,18 @@
+
+export CONDA_TARGET_DIR=/p/project/cesmtst/hoeflich1/miniconda3
+
+if [ "${1}" == "install" ]; then
+
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b -f -p ${CONDA_TARGET_DIR}
+${CONDA_TARGET_DIR}/bin/conda install -n base -c conda-forge jupyterlab dask distributed bokeh dask-jobqueue
+${CONDA_TARGET_DIR}/bin/conda clean --all --yes
+
+else
+
+source ${CONDA_TARGET_DIR}/etc/profile.d/conda.sh
+conda activate base && \
+jupyter lab --ip=$HOSTNAME --no-browser
+
+fi
+

--- a/juwels/00_juwels-node-characteristics.ipynb
+++ b/juwels/00_juwels-node-characteristics.ipynb
@@ -1,0 +1,543 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JUWELS at JSC compute node characteristics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Free memory for `batch`, `devel`, `esm` and `large` partitions,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "top - 17:12:32 up  1:40,  1 user,  load average: 14.19, 36.95, 34.24\n",
+      "Tasks: 929 total,   1 running, 928 sleeping,   0 stopped,   0 zombie\n",
+      "%Cpu(s):  0.2 us,  0.4 sy,  0.0 ni, 99.4 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st\n",
+      "MiB Mem :  94806.0 total,  76286.3 free,   5530.6 used,  12989.2 buff/cache\n",
+      "MiB Swap:      0.0 total,      0.0 free,      0.0 used.  85798.4 avail Mem \n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "srun --account=esmtst --time=00:01:00 --partition=batch top -b -n 1 | head -n 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!scontrol -o show nodes > node_state.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('node_state.txt') as f:\n",
+    "    lines = f.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matchers = ['NodeName=', 'CPUTot=', 'RealMemory=', 'FreeMem=', 'State=', 'Partitions=']\n",
+    "with open('node_state_parsed.txt','w') as f:\n",
+    "    for i in range(len(lines)):\n",
+    "        my_list = lines[i].split(' ')\n",
+    "        matching = [s for s in my_list if any(xs in s for xs in matchers)]\n",
+    "        f.write(';'.join(matching)+'\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c1 = lambda x: (x.replace('NodeName=',''))\n",
+    "c2 = lambda x: (x.replace('RealMemory=',''))\n",
+    "c3 = lambda x: (x.replace('FreeMem=',''))\n",
+    "c4 = lambda x: (x.replace('State=',''))\n",
+    "c5 = lambda x: (x.replace('Partitions=',''))\n",
+    "c6 = lambda x: (x.replace('CPUTot=',''))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pandas.read_csv('node_state_parsed.txt', delimiter=';', header=None,\n",
+    "    names=['NodeName', 'CPUTot', 'RealMemory', 'FreeMem', 'State', 'Partitions'],\n",
+    "    converters={'NodeName':c1, 'RealMemory':c2, 'FreeMem':c3, 'State':c4, 'Partitions':c5, 'CPUTot':c6},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>NodeName</th>\n",
+       "      <th>CPUTot</th>\n",
+       "      <th>RealMemory</th>\n",
+       "      <th>FreeMem</th>\n",
+       "      <th>State</th>\n",
+       "      <th>Partitions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>jwb0001</td>\n",
+       "      <td>96</td>\n",
+       "      <td>515712</td>\n",
+       "      <td>487030</td>\n",
+       "      <td>ALLOCATED</td>\n",
+       "      <td>develbooster,maintbooster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>jwb0002</td>\n",
+       "      <td>96</td>\n",
+       "      <td>515712</td>\n",
+       "      <td>487032</td>\n",
+       "      <td>RESERVED</td>\n",
+       "      <td>booster,largebooster,maintbooster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>jwb0003</td>\n",
+       "      <td>96</td>\n",
+       "      <td>515712</td>\n",
+       "      <td>486806</td>\n",
+       "      <td>RESERVED</td>\n",
+       "      <td>booster,largebooster,maintbooster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>jwb0004</td>\n",
+       "      <td>96</td>\n",
+       "      <td>515712</td>\n",
+       "      <td>485974</td>\n",
+       "      <td>RESERVED</td>\n",
+       "      <td>booster,largebooster,maintbooster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>jwb0005</td>\n",
+       "      <td>96</td>\n",
+       "      <td>515712</td>\n",
+       "      <td>486637</td>\n",
+       "      <td>RESERVED</td>\n",
+       "      <td>booster,largebooster,maintbooster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3498</th>\n",
+       "      <td>jwc09n165</td>\n",
+       "      <td>80</td>\n",
+       "      <td>180000</td>\n",
+       "      <td>N/A</td>\n",
+       "      <td>DOWN*+DRAIN</td>\n",
+       "      <td>gpus,maintcluster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3499</th>\n",
+       "      <td>jwc09n174</td>\n",
+       "      <td>80</td>\n",
+       "      <td>180000</td>\n",
+       "      <td>157559</td>\n",
+       "      <td>ALLOCATED</td>\n",
+       "      <td>gpus,maintcluster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3500</th>\n",
+       "      <td>jwc09n177</td>\n",
+       "      <td>80</td>\n",
+       "      <td>180000</td>\n",
+       "      <td>146424</td>\n",
+       "      <td>ALLOCATED</td>\n",
+       "      <td>gpus,maintcluster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3501</th>\n",
+       "      <td>jwc09n180</td>\n",
+       "      <td>80</td>\n",
+       "      <td>180000</td>\n",
+       "      <td>133886</td>\n",
+       "      <td>ALLOCATED</td>\n",
+       "      <td>gpus,maintcluster,maint</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3502</th>\n",
+       "      <td>jwc09n183</td>\n",
+       "      <td>80</td>\n",
+       "      <td>180000</td>\n",
+       "      <td>140655</td>\n",
+       "      <td>ALLOCATED</td>\n",
+       "      <td>gpus,maintcluster,maint</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3503 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       NodeName CPUTot RealMemory FreeMem        State  \\\n",
+       "0       jwb0001     96     515712  487030    ALLOCATED   \n",
+       "1       jwb0002     96     515712  487032     RESERVED   \n",
+       "2       jwb0003     96     515712  486806     RESERVED   \n",
+       "3       jwb0004     96     515712  485974     RESERVED   \n",
+       "4       jwb0005     96     515712  486637     RESERVED   \n",
+       "...         ...    ...        ...     ...          ...   \n",
+       "3498  jwc09n165     80     180000     N/A  DOWN*+DRAIN   \n",
+       "3499  jwc09n174     80     180000  157559    ALLOCATED   \n",
+       "3500  jwc09n177     80     180000  146424    ALLOCATED   \n",
+       "3501  jwc09n180     80     180000  133886    ALLOCATED   \n",
+       "3502  jwc09n183     80     180000  140655    ALLOCATED   \n",
+       "\n",
+       "                                   Partitions  \n",
+       "0             develbooster,maintbooster,maint  \n",
+       "1     booster,largebooster,maintbooster,maint  \n",
+       "2     booster,largebooster,maintbooster,maint  \n",
+       "3     booster,largebooster,maintbooster,maint  \n",
+       "4     booster,largebooster,maintbooster,maint  \n",
+       "...                                       ...  \n",
+       "3498                  gpus,maintcluster,maint  \n",
+       "3499                  gpus,maintcluster,maint  \n",
+       "3500                  gpus,maintcluster,maint  \n",
+       "3501                  gpus,maintcluster,maint  \n",
+       "3502                  gpus,maintcluster,maint  \n",
+       "\n",
+       "[3503 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = df['Partitions'].str.contains('|'.join(['batch', 'devel', 'esm', 'large'])) \\\n",
+    "& df['State'].str.contains('IDLE') \\\n",
+    "& ~df['Partitions'].str.contains('mem192')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "90000 86866\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df[mask]['RealMemory'].max(), df[mask]['FreeMem'].max()) # MiB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mount points for `batch` partition compute nodes,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filesystem           1K-blocks          Used     Available Use% Mounted on\n",
+      "devtmpfs              48512736             0      48512736   0% /dev\n",
+      "tmpfs                 48540680          2044      48538636   1% /run\n",
+      "tmpfs                 48540680             0      48540680   0% /sys/fs/cgroup\n",
+      "tmpfs                 48540680       2763732      45776948   6% /\n",
+      "tmpfs                 48540680             4      48540676   1% /dev/shm\n",
+      "tmpfs                  9708136             0       9708136   0% /run/user/0\n",
+      "scratch         14850371616768 6745390759936 8104980856832  46% /p/scratch\n",
+      "fastdata         9900247744512 7748817567744 2151430176768  79% /p/fastdata\n",
+      "hpcmon             17423376384    9409325056    8014051328  55% /p/hpcmon\n",
+      "project          4125103226880 2391816388608 1733286838272  58% /p/project\n",
+      "usersoftware       34458402816     359219200   34099183616   2% /p/usersoftware\n",
+      "juwels_software    17229201408    4362436608   12866764800  26% /p/software/juwels\n",
+      "home               64509345792   12161220608   52348125184  19% /p/home\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "srun: job 3256254 queued and waiting for resources\n",
+      "srun: job 3256254 has been allocated resources\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "srun --account=esmtst --time=00:01:00 --partition=batch df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Python environment,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# This file may be used to create an environment using:\n",
+      "# $ conda create --name <env> --file <this file>\n",
+      "# platform: linux-64\n",
+      "@EXPLICIT\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2020.12.5-ha878542_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.33.1-h53a641e_7.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran4-7.5.0-hae1eefd_17.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandoc-2.11.3.2-h7f98852_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.5.0-hae1eefd_17.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9d-h36c2ea0_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.12-pthreads_hb3c22a3_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.2-he1b5a44_3.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.2-he6710b0_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1i-h27cfd23_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.11-h7b6447c_3.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-7_openblas.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20191231-h14c3975_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-h21135ba_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/readline-8.0-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.10-hbc83047_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.5-h9ceee32_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-7_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-7_openblas.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.1.0-h2733197_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.33.0-h62c20be_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.11-hcbb858e_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.5-h7579374_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/attrs-20.3.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-py_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/chardet-3.0.4-py38h06a4308_1003.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/click-7.1.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.3-pyhd8ed1ab_1003.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.8.5-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/idna-2.10-py_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/json5-0.9.5-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.1-py38hff7bd54_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.4.3-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/olefile-0.46-pyh9f0ad1d_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.4.2-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.1-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.9.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.7.2-py38h7b6447c_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.3-py38h7b6447c_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.20-py_2.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.7-pyh9f0ad1d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-1_cp38.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pytz-2020.5-pyhd8ed1ab_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.15.87-py38h7b6447c_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/send2trash-1.5.0-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/six-1.15.0-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.3.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/tblib-1.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/testpath-0.4.4-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.1-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/tqdm-4.51.0-pyhd3eb1b0_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.7.4.3-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zipp-3.4.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/babel-2.9.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2020.12.5-py38h578d9bd_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.14.3-py38h261ae71_2.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-1.7.2-py38h03888b9_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.11.0-py38h25fe258_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-3.3.0-py38h578d9bd_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.18.0-py38h578d9bd_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py38h8df0ef7_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/mistune-0.8.4-py38h25fe258_1002.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.18.5-py38h8854b6b_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.8-pyhd3deb0d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/partd-1.1.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh9f0ad1d_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.2.0-py38h9776b28_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.17.3-py38h25fe258_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3.1-py38h8df0ef7_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-20.0.0-py38h1d1b12f_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/sniffio-1.2.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py38h25fe258_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.0.5-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zict-2.0.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/anyio-2.0.2-py38h578d9bd_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-20.1.0-py38h25fe258_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py38h27cfd23_1003.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/cryptography-3.2.1-py38h3c74f83_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2020.12.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-3.3.0-hd8ed1ab_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.7.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.4-py38h0ef3d22_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/setuptools-50.3.1-py38h06a4308_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.2-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/bleach-3.2.1-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/distributed-2020.12.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jsonschema-3.2.0-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyter_client-6.1.7-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pip-20.2.4-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.7.3-pyhd8ed1ab_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/pyopenssl-19.1.0-pyhd3eb1b0_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.2-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/urllib3-1.25.11-py_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-2020.12.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbclient-0.5.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.9-pyha770c72_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/requests-2.24.0-py_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/conda-4.9.2-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.19.0-py38h81c977d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h578d9bd_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.4.2-py38h81c977d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_server-1.1.4-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.0.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/notebook-6.1.6-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.5-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.1-pyhd8ed1ab_0.tar.bz2\n"
+     ]
+    }
+   ],
+   "source": [
+    "!conda list --explicit"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/juwels/01_jobqueue_cluster_example.ipynb
+++ b/juwels/01_jobqueue_cluster_example.ipynb
@@ -49,22 +49,25 @@
      "data": {
       "text/plain": [
        "{'cores': 96,\n",
-       " 'memory': '90000M',\n",
+       " 'memory': '86864MiB',\n",
        " 'processes': 1,\n",
-       " 'local-directory': '/tmp',\n",
+       " 'local-directory': None,\n",
        " 'death-timeout': 60,\n",
-       " 'extra': ['--host ${SLURMD_NODENAME}.ib.juwels.fzj.de'],\n",
-       " 'interface': None,\n",
+       " 'extra': [],\n",
+       " 'interface': 'ib0',\n",
        " 'shebang': '#!/usr/bin/env bash',\n",
        " 'walltime': '00:15:00',\n",
-       " 'log-directory': 'dask_jobqueue_logs',\n",
+       " 'log-directory': 'dask-jobqueue-logs',\n",
        " 'name': 'dask-worker',\n",
-       " 'queue': None,\n",
+       " 'env-extra': ['export DASK_DISTRIBUTED__WORKER__MEMORY__SPILL=False',\n",
+       "  'export DASK_DISTRIBUTED__WORKER__MEMORY__TARGET=False',\n",
+       "  'export DASK_DISTRIBUTED__WORKER__MEMORY__PAUSE=0.8',\n",
+       "  'export DASK_DISTRIBUTED__WORKER__MEMORY__TERMINATE=0.9'],\n",
        " 'project': None,\n",
+       " 'queue': None,\n",
        " 'job-cpu': None,\n",
        " 'job-mem': None,\n",
-       " 'job-extra': [],\n",
-       " 'env-extra': []}"
+       " 'job-extra': []}"
       ]
      },
      "execution_count": 3,
@@ -80,7 +83,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set up jobqueue cluster ..."
+    "## Inspect cluster utilization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Overview about idle nodes for each batch partition. This is, however, only a very general overview. As the scheduler reserves compute nodes for jobs that are already chosen to start-up very soon, and as the scheduler still reports these reserved nodes as being \"idle\", the numbers below are not necessarily related to the actual number of readily usable compute nodes."
    ]
   },
   {
@@ -93,37 +103,99 @@
      "output_type": "stream",
      "text": [
       "PARTITION AVAIL NODES STATE\n",
-      "batch*       up   141  idle\n",
-      "mem192       up    10  idle\n",
+      "batch*       up   279  idle\n",
+      "devel        up    19  idle\n",
+      "mem192       up    90  idle\n",
+      "esm          up     6  idle\n",
+      "large      down   279  idle\n",
       "gpus         up     0   n/a\n",
-      "devel        up    20  idle\n",
-      "esm          up     5  idle\n",
-      "develgpus    up     9  idle\n",
-      "large      down   141  idle\n",
-      "maint        up   175  idle\n"
+      "develgpus    up     8  idle\n",
+      "booster      up   345  idle\n",
+      "develboos    up     7  idle\n",
+      "largeboos    up   345  idle\n",
+      "maintclus    up   312  idle\n",
+      "maintboos    up   352  idle\n",
+      "maint        up   664  idle\n"
      ]
     }
    ],
    "source": [
-    "!sinfo -t idle --format=\"%9P %.5a %.5D %.5t\" # get overview on available resources per queue"
+    "%%bash\n",
+    "sinfo -t idle --format=\"%9P %.5a %.5D %.5t\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A more accurate overview on which batch partition to choose for the Dask jobqueue cluster can be obtained by submitting `--test-only` requests and by looking at the start date estimates. If the reported date is very, very close to the current date it can be expected that a Dask cluster as specified in the `test_this_jobqueue_cluster` variable starts-up almost immediately. Note, that on JUWELS `--nodes 3` is the number of Dask jobqueue workers that would be requested by a `cluster.scale(jobs=3)`. Also note, that the scheduler on JUWELS has a backfilling mechanism and that Dask jobqueue workers might start-up after a few minutes, even though the date reported by the `--test-only` requests report otherwise."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thu Jan  7 17:10:37 CET 2021\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "sbatch: Job 3256240 to start at 2021-01-07T17:57:38 using 288 processors on nodes jwc03n[130-132] in partition batch\n",
+      "sbatch: Job 3256241 to start at 2021-01-07T17:10:38 using 288 processors on nodes jwc00n[016-018] in partition devel\n",
+      "sbatch: Job 3256242 to start at 2021-01-07T17:10:38 using 288 processors on nodes jwc08n[075-077] in partition mem192\n",
+      "sbatch: Job 3256243 to start at 2021-01-07T17:10:38 using 288 processors on nodes jwc00n[000,003,006] in partition esm\n",
+      "sbatch: Job 3256244 to start at 2021-01-07T17:10:39 using 288 processors on nodes jwc03n[130-132] in partition large\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid account or account/partition combination specified\n",
+      "allocation failure: Invalid generic resource (gres) specification\n",
+      "allocation failure: Invalid account or account/partition combination specified\n"
+     ]
+    }
+   ],
    "source": [
-    "jobqueue_cluster = dask_jobqueue.SLURMCluster(\n",
-    "    config_name='juwels-jobqueue-config',\n",
-    "    project='esmtst', # specify budget name associated with project\n",
-    "    queue='esm', # choose queue by available resources\n",
-    "    host=os.environ['HOSTNAME']) # globally visible local scheduler network location"
+    "%%bash\n",
+    "\n",
+    "test_jobqueue_cluster='--nodes 3 --time 00:15:00 --account esmtst --cpus-per-task=96 --mem=85G'\n",
+    "\n",
+    "date && scontrol show partition | grep PartitionName | cut -f2 -d\"=\" | \\\n",
+    "xargs -I {} bash -c \"sbatch --test-only ${test_jobqueue_cluster} --partition {} --wrap 'echo $HOST'\"\n",
+    "printf \"\" # prevent display of xargs non-zero exit codes..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up jobqueue cluster ..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobqueue_cluster = dask_jobqueue.SLURMCluster(\n",
+    "    config_name='juwels-jobqueue-config',\n",
+    "    project='esmtst', # specify budget name associated with your project\n",
+    "    queue='devel', # choose batch partition by available resources\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -135,16 +207,17 @@
       "#SBATCH -J dask-worker\n",
       "#SBATCH -e dask_jobqueue_logs/dask-worker-%J.err\n",
       "#SBATCH -o dask_jobqueue_logs/dask-worker-%J.out\n",
-      "#SBATCH -p esm\n",
+      "#SBATCH -p devel\n",
       "#SBATCH -A esmtst\n",
       "#SBATCH -n 1\n",
       "#SBATCH --cpus-per-task=96\n",
-      "#SBATCH --mem=84G\n",
+      "#SBATCH --mem=85G\n",
       "#SBATCH -t 00:15:00\n",
-      "\n",
-      "JOB_ID=${SLURM_JOB_ID%;*}\n",
-      "\n",
-      "/p/project/cesmtst/hoeflich1/miniconda3/envs/Dask-jobqueue_v2020.02.10/bin/python -m distributed.cli.dask_worker tcp://10.11.159.196:37444 --nthreads 96 --memory-limit 90.00GB --name name --nanny --death-timeout 60 --local-directory /tmp --host ${SLURMD_NODENAME}.ib.juwels.fzj.de\n",
+      "export DASK_DISTRIBUTED__WORKER__MEMORY__SPILL=False\n",
+      "export DASK_DISTRIBUTED__WORKER__MEMORY__TARGET=False\n",
+      "export DASK_DISTRIBUTED__WORKER__MEMORY__PAUSE=0.8\n",
+      "export DASK_DISTRIBUTED__WORKER__MEMORY__TERMINATE=0.9\n",
+      "/p/project/cesmtst/hoeflich1/miniconda3/bin/python -m distributed.cli.dask_worker tcp://10.13.0.158:35955 --nthreads 96 --memory-limit 91.08GB --name dummy-name --nanny --death-timeout 60 --interface ib0 --protocol tcp://\n",
       "\n"
      ]
     }
@@ -162,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,16 +251,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "jobqueue_cluster.scale(jobs=1)"
+    "jobqueue_cluster.scale(jobs=3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -195,7 +268,9 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2164705       esm dask-wor hoeflich  R       0:23      1 jwc00n003\n"
+      "           3256247     devel dask-wor hoeflich  R       0:11      1 jwc00n004\n",
+      "           3256248     devel dask-wor hoeflich  R       0:11      1 jwc00n005\n",
+      "           3256246     devel dask-wor hoeflich  R       0:15      1 jwc00n002\n"
      ]
     }
    ],
@@ -205,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -216,26 +291,26 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://10.11.159.196:37444</li>\n",
-       "  <li><b>Dashboard: </b><a href='http://10.11.159.196:8787/status' target='_blank'>http://10.11.159.196:8787/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.13.0.158:35955</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.13.0.158:8787/status' target='_blank'>http://10.13.0.158:8787/status</a></li>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Cluster</h3>\n",
        "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>1</li>\n",
-       "  <li><b>Cores: </b>96</li>\n",
-       "  <li><b>Memory: </b>90.00 GB</li>\n",
+       "  <li><b>Workers: </b>3</li>\n",
+       "  <li><b>Cores: </b>288</li>\n",
+       "  <li><b>Memory: </b>273.24 GB</li>\n",
        "</ul>\n",
        "</td>\n",
        "</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "<Client: 'tcp://10.11.159.196:37444' processes=1 threads=96, memory=90.00 GB>"
+       "<Client: 'tcp://10.13.0.158:35955' processes=3 threads=288, memory=273.24 GB>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -306,7 +381,6 @@
        "  <line x1=\"10\" y1=\"96\" x2=\"29\" y2=\"115\" />\n",
        "  <line x1=\"10\" y1=\"102\" x2=\"29\" y2=\"121\" />\n",
        "  <line x1=\"10\" y1=\"108\" x2=\"29\" y2=\"127\" />\n",
-       "  <line x1=\"10\" y1=\"114\" x2=\"29\" y2=\"133\" />\n",
        "  <line x1=\"10\" y1=\"120\" x2=\"29\" y2=\"139\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -314,7 +388,7 @@
        "  <line x1=\"29\" y1=\"19\" x2=\"29\" y2=\"139\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.000000,0.000000 29.161809,19.161809 29.161809,139.161809 10.000000,120.000000\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 29.16180906316908,19.16180906316908 29.16180906316908,139.16180906316907 10.0,120.0\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
@@ -340,11 +414,10 @@
        "  <line x1=\"106\" y1=\"0\" x2=\"125\" y2=\"19\" />\n",
        "  <line x1=\"112\" y1=\"0\" x2=\"131\" y2=\"19\" />\n",
        "  <line x1=\"118\" y1=\"0\" x2=\"137\" y2=\"19\" />\n",
-       "  <line x1=\"124\" y1=\"0\" x2=\"143\" y2=\"19\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"149\" y2=\"19\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.000000,0.000000 130.000000,0.000000 149.161809,19.161809 29.161809,19.161809\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"10.0,0.0 130.0,0.0 149.16180906316907,19.16180906316908 29.16180906316908,19.16180906316908\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"29\" y1=\"19\" x2=\"149\" y2=\"19\" style=\"stroke-width:2\" />\n",
@@ -366,7 +439,6 @@
        "  <line x1=\"29\" y1=\"115\" x2=\"149\" y2=\"115\" />\n",
        "  <line x1=\"29\" y1=\"121\" x2=\"149\" y2=\"121\" />\n",
        "  <line x1=\"29\" y1=\"127\" x2=\"149\" y2=\"127\" />\n",
-       "  <line x1=\"29\" y1=\"133\" x2=\"149\" y2=\"133\" />\n",
        "  <line x1=\"29\" y1=\"139\" x2=\"149\" y2=\"139\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -389,11 +461,10 @@
        "  <line x1=\"125\" y1=\"19\" x2=\"125\" y2=\"139\" />\n",
        "  <line x1=\"131\" y1=\"19\" x2=\"131\" y2=\"139\" />\n",
        "  <line x1=\"137\" y1=\"19\" x2=\"137\" y2=\"139\" />\n",
-       "  <line x1=\"143\" y1=\"19\" x2=\"143\" y2=\"139\" />\n",
        "  <line x1=\"149\" y1=\"19\" x2=\"149\" y2=\"139\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"29.161809,19.161809 149.161809,19.161809 149.161809,139.161809 29.161809,139.161809\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "  <polygon points=\"29.16180906316908,19.16180906316908 149.16180906316907,19.16180906316908 149.16180906316907,139.16180906316907 29.16180906316908,139.16180906316907\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
        "\n",
        "  <!-- Text -->\n",
        "  <text x=\"89.161809\" y=\"159.161809\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >10000</text>\n",
@@ -408,7 +479,7 @@
        "dask.array<uniform, shape=(365, 10000, 10000), dtype=float64, chunksize=(365, 500, 500), chunktype=numpy.ndarray>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,14 +500,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "elapse time  12.483904123306274  in seconds\n"
+      "elapse time  5.86717677116394  in seconds\n"
      ]
     }
    ],
@@ -456,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +535,9 @@
      "output_type": "stream",
      "text": [
       "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "           2164705       esm dask-wor hoeflich  R       1:06      1 jwc00n003\n"
+      "           3256247     devel dask-wor hoeflich  R       0:42      1 jwc00n004\n",
+      "           3256248     devel dask-wor hoeflich  R       0:42      1 jwc00n005\n",
+      "           3256246     devel dask-wor hoeflich  R       0:46      1 jwc00n002\n"
      ]
     }
    ],
@@ -474,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -508,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -519,109 +592,154 @@
       "# $ conda create --name <env> --file <this file>\n",
       "# platform: linux-64\n",
       "@EXPLICIT\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2019.11.28-hecc5488_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.33.1-h53a641e_8.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.3.0-hdf63c60_5.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.2.0-hdf63c60_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.2.0-h24d8f2e_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-0_gnu.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.2.0-h24d8f2e_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9c-h14c3975_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libffi-3.2.1-he1b5a44_1006.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.7-h5ec1e0e_6.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.17-h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.8.3-he1b5a44_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.1-hf484d3e_1002.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1d-h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.4-h14c3975_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.2-h516909a_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1006.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-hed695b0_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-hf8c457e_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-hed695b0_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.2-he1b5a44_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.4-h3b9ef0a_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.0-he983fc9_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.8.0-14_openblas.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.1.0-hc3755c2_3.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.30.1-hcee41ef_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/python-3.8.1-h357f687_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.1.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2019.11.28-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/click-7.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.2.2-py_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2.10.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/entrypoints-0.3-py38_1000.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.6.2-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/_libgcc_mutex-0.1-main.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2020.12.5-ha878542_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ld_impl_linux-64-2.33.1-h53a641e_7.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran4-7.5.0-hae1eefd_17.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libstdcxx-ng-9.1.0-hdf63c60_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandoc-2.11.3.2-h7f98852_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libgcc-ng-9.1.0-hdf63c60_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-7.5.0-hae1eefd_17.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jpeg-9d-h36c2ea0_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libffi-3.3-he6710b0_2.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.12-pthreads_hb3c22a3_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.2-he1b5a44_3.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.2-he6710b0_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1i-h27cfd23_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.5-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/yaml-0.2.5-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.11-h7b6447c_3.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-7_openblas.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libedit-3.1.20191231-h14c3975_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-h21135ba_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/readline-8.0-h7b6447c_0.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.10-hbc83047_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/zstd-1.4.5-h9ceee32_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-7_openblas.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-7_openblas.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.1.0-h2733197_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.33.0-h62c20be_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.11-hcbb858e_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/python-3.8.5-h7579374_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/attrs-20.3.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-py_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/chardet-3.0.4-py38h06a4308_1003.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/click-7.1.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/cloudpickle-1.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.2-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.6.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.3-pyhd8ed1ab_1003.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/fsspec-0.8.5-pyhd8ed1ab_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/idna-2.10-py_0.conda\n",
       "https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/json5-0.9.5-pyh9f0ad1d_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-0.6.2-py38hc9558a2_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.18.1-py38h95a1406_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/olefile-0.46-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/parso-0.6.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pickleshare-0.7.5-py38_1000.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.6.7-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.6.0-py_1001.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.6-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pytz-2019.3-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-18.1.1-py38h1768529_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/six-1.14.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.1.0-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/msgpack-python-1.0.1-py38hff7bd54_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.4.3-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/olefile-0.46-pyh9f0ad1d_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.4.2-py_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.1-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.9.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/psutil-5.7.2-py38h7b6447c_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pycosat-0.6.3-py38h7b6447c_1.conda\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/pycparser-2.20-py_2.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pyparsing-2.4.7-pyh9f0ad1d_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-1_cp38.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pytz-2020.5-pyhd8ed1ab_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/ruamel_yaml-0.15.87-py38h7b6447c_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/send2trash-1.5.0-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/six-1.15.0-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.3.0-pyhd8ed1ab_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/tblib-1.6.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/toolz-0.10.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.0.3-py38h516909a_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.1.8-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.10.1-py38h516909a_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.16.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/testpath-0.4.4-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/toolz-0.11.1-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/tqdm-4.51.0-pyhd3eb1b0_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-3.7.4.3-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/wheel-0.35.1-pyhd3eb1b0_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zipp-3.4.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/babel-2.9.0-pyhd3deb0d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/certifi-2020.12.5-py38h578d9bd_1.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/cffi-1.14.3-py38h261ae71_2.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/conda-package-handling-1.7.2-py38h03888b9_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.11.0-py38h25fe258_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-3.3.0-py38h578d9bd_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jedi-0.18.0-py38h578d9bd_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/markupsafe-1.1.1-py38h8df0ef7_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/mistune-0.8.4-py38h25fe258_1002.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.18.5-py38h8854b6b_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/packaging-20.8-pyhd3deb0d_0.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/partd-1.1.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pexpect-4.8.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.0.0-py38hefe7db6_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh9f0ad1d_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pillow-7.2.0-py38h9776b28_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.17.3-py38h25fe258_1.tar.bz2\n",
       "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/setuptools-45.2.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/traitlets-4.3.3-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/zict-1.0.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/distributed-2.10.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.6.1-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.0.1-py38hb3f55d8_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.5.2-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/wheel-0.34.2-py_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-1.4.0-py38_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.0-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_client-5.3.4-py38_1.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/pip-20.0.2-py_2.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.3-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/noarch/dask-2.10.1-py_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.12.0-py38h5ca1d4c_0.tar.bz2\n",
-      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.1.4-py38h5ca1d4c_0.tar.bz2\n"
+      "https://conda.anaconda.org/conda-forge/linux-64/pyyaml-5.3.1-py38h8df0ef7_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pyzmq-20.0.0-py38h1d1b12f_1.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/sniffio-1.2.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py38h25fe258_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.0.5-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/zict-2.0.0-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/anyio-2.0.2-py38h578d9bd_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-20.1.0-py38h25fe258_2.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/brotlipy-0.7.0-py38h27cfd23_1003.conda\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/cryptography-3.2.1-py38h3c74f83_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-core-2020.12.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-3.3.0-hd8ed1ab_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.7.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/pandas-1.1.4-py38h0ef3d22_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/setuptools-50.3.1-py38h06a4308_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/terminado-0.9.2-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/bleach-3.2.1-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/distributed-2020.12.0-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jinja2-2.11.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jsonschema-3.2.0-py_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyter_client-6.1.7-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/linux-64/pip-20.2.4-py38h06a4308_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/pygments-2.7.3-pyhd8ed1ab_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/pyopenssl-19.1.0-pyhd3eb1b0_1.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-jobqueue-0.7.2-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/urllib3-1.25.11-py_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/dask-2020.12.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbclient-0.5.1-py_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.9-pyha770c72_0.tar.bz2\n",
+      "https://repo.anaconda.com/pkgs/main/noarch/requests-2.24.0-py_0.conda\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/conda-4.9.2-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipython-7.19.0-py38h81c977d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/nbconvert-6.0.7-py38h578d9bd_3.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/ipykernel-5.4.2-py38h81c977d_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/jupyter_server-1.1.4-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.0.0-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/linux-64/notebook-6.1.6-py38h578d9bd_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.5-pyhd8ed1ab_0.tar.bz2\n",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.1-pyhd8ed1ab_0.tar.bz2\n"
      ]
     }
    ],
    "source": [
     "!conda list --explicit"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:Dask-jobqueue_v2020.02.10]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-Dask-jobqueue_v2020.02.10-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -633,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/juwels/juwels-dask-jobqueue-config.yaml
+++ b/juwels/juwels-dask-jobqueue-config.yaml
@@ -5,38 +5,45 @@ jobqueue:
 
     ### Dask jobqueue worker options ###
 
-    cores: 96        # use full node CPU and memory resources
-    memory: 90000M   # e.g. $ control show node jwc00n018
-    
-    processes: 1     # good only for pure Numpy workflows
+    cores: 96
+    memory: 86864MiB
 
-    local-directory: /tmp
+    processes: 1
+
+    local-directory: null
     death-timeout: 60
 
-    extra: ['--host ${SLURMD_NODENAME}.ib.juwels.fzj.de'] # globally visible compute node network location
-    interface: null  # don't use this option!
+    extra: []
+    interface: ib0
 
     ### SLURM job script options ####
 
     shebang: '#!/usr/bin/env bash'
     walltime: '00:15:00'
-    log-directory: dask_jobqueue_logs
+    log-directory: dask-jobqueue-logs
     name: dask-worker
-
-    # depend on project affiliation
-    # should be set manually!
     
-    queue: null
-    project: null
+    # https://docs.dask.org/en/latest/setup/hpc.html
 
-    # these are automatically set
+    env-extra: ['export DASK_DISTRIBUTED__WORKER__MEMORY__SPILL=False',
+                'export DASK_DISTRIBUTED__WORKER__MEMORY__TARGET=False',
+                'export DASK_DISTRIBUTED__WORKER__MEMORY__PAUSE=0.8',
+                'export DASK_DISTRIBUTED__WORKER__MEMORY__TERMINATE=0.9']
+
+    # these depend on project affiliation
+    # and ready-to-use compute resources, and
+    # therefore should be set manually
+    
+    project: null
+    queue: null
+
+    # for SLURM clusters these are automatically set
     # by the Dask worker options above
     
     job-cpu: null
     job-mem: null
 
-    # mandatory for
-    # standalone configurations
+    # these are stated here because they are mandatory for
+    # Dask jobqueue standalone configurations
     
     job-extra: []
-    env-extra: []


### PR DESCRIPTION
This solves the network problems reported in #12, and the diskless node issues from #11. I've also added the `--test-only` approach from [here](https://github.com/ExaESM-WP4/Dask-scheduling-scenarios/blob/ed61481965b9a6faee2e97437a436f75c20b86a9/01_Scheduler-conveniences.ipynb), which helps to more accurately check out which batch partition to choose for the Dask jobqueue cluster.